### PR TITLE
Fix/makefile dotenv

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -53,7 +53,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Build documentation
-        run: poetry run pdoc --docformat google src/{{ cookiecutter.package_name }} -o docs
+        run: poetry run pdoc --docformat google src/aiai_eval -o docs
 
       - name: Compress documentation
         run: tar --directory docs/ -hcf artifact.tar .

--- a/makefile
+++ b/makefile
@@ -51,18 +51,12 @@ setup-git:
 	fi
 
 docs:
-	@poetry run pdoc --docformat google src/{{cookiecutter.package_name}} -o docs
+	@poetry run pdoc --docformat google src/aiai_eval -o docs
 	@echo "Saved documentation."
 
 view-docs:
 	@echo "Viewing API documentation..."
-	@open docs/{{cookiecutter.package_name}}.html
-
-clean:
-	@find . -type f -name "*.py[co]" -delete
-	@find . -type d -name "__pycache__" -delete
-	@rm -rf .pytest_cache
-	@echo "Cleaned repository."
+	@open docs/aiai_eval.html
 
 bump-major:
 	@poetry run python -m src.scripts.versioning --major

--- a/makefile
+++ b/makefile
@@ -5,9 +5,13 @@
 # Exports all variables defined in the makefile available to scripts
 .EXPORT_ALL_VARIABLES:
 
+# Includes environment variables from the .env file
+include .env
+
 install-poetry:
 	@echo "Installing poetry..."
 	@curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+	@$(eval include ${HOME}/.poetry/env)
 
 uninstall-poetry:
 	@echo "Uninstalling poetry..."
@@ -16,42 +20,43 @@ uninstall-poetry:
 install:
 	@echo "Installing..."
 	@if [ "$(shell which poetry)" = "" ]; then \
-		make install-poetry; \
+		$(MAKE) install-poetry; \
 	fi
 	@if [ "$(shell which gpg)" = "" ]; then \
 		echo "GPG not installed, so an error will occur. Install GPG on MacOS with "\
 			 "`brew install gnupg` or on Ubuntu with `apt install gnupg` and run "\
 			 "`make install` again."; \
 	fi
+	@$(MAKE) setup-poetry
+	@$(MAKE) setup-git
+
+setup-poetry:
 	@poetry env use python3
 	@poetry run python3 -m src.scripts.fix_dot_env_file
-	@git init
-	@. .env; \
-		git config --local user.name "$${GIT_NAME}"; \
-		git config --local user.email "$${GIT_EMAIL}"
-	@. .env; \
-		if [ "$${GPG_KEY_ID}" = "" ]; then \
-			echo "No GPG key ID specified. Skipping GPG signing."; \
-			git config --local commit.gpgsign false; \
-		else \
-			echo "Signing with GPG key ID $${GPG_KEY_ID}..."; \
-			git config --local commit.gpgsign true; \
-			git config --local user.signingkey "$${GPG_KEY_ID}"; \
-		fi
 	@poetry install
 	@poetry run pre-commit install
 
-remove-env:
-	@poetry env remove python3
-	@echo "Removed virtual environment."
+setup-git:
+	@git init
+	@git config --local user.name ${GIT_NAME}
+	@git config --local user.email ${GIT_EMAIL}
+	@if [ ${GPG_KEY_ID} = "" ]; then \
+		echo "No GPG key ID specified. Skipping GPG signing."; \
+		git config --local commit.gpgsign false; \
+	else \
+		echo "Signing with GPG key ID ${GPG_KEY_ID}..."; \
+		echo 'If you get the "failed to sign the data" error when committing, try running `export GPG_TTY=$$(tty)`.'; \
+		git config --local commit.gpgsign true; \
+		git config --local user.signingkey ${GPG_KEY_ID}; \
+	fi
 
 docs:
-	@poetry run pdoc --docformat google src/aiai_eval -o docs
+	@poetry run pdoc --docformat google src/{{cookiecutter.package_name}} -o docs
 	@echo "Saved documentation."
 
 view-docs:
 	@echo "Viewing API documentation..."
-	@open docs/aiai_eval.html
+	@open docs/{{cookiecutter.package_name}}.html
 
 clean:
 	@find . -type f -name "*.py[co]" -delete
@@ -72,15 +77,15 @@ bump-patch:
 	@echo "Bumped patch version."
 
 publish:
-	@. .env; \
-		printf "Preparing to publish to PyPI. Have you ensured to change the package version with 'make bump-X' for 'X' being 'major', 'minor' or 'patch'? [y/n] : "; \
+	@$(eval include .env)
+	@printf "Preparing to publish to PyPI. Have you ensured to change the package version with 'make bump-X' for 'X' being 'major', 'minor' or 'patch'? [y/n] : "; \
 		read -r answer; \
 		if [ "$${answer}" = "y" ]; then \
-			if [ "$${PYPI_API_TOKEN}" = "" ]; then \
+			if [ "${PYPI_API_TOKEN}" = "" ]; then \
 				echo "No PyPI API token specified in the '.env' file, so cannot publish."; \
 			else \
 				echo "Publishing to PyPI..."; \
-				poetry publish --build --username "__token__" --password "$${PYPI_API_TOKEN}"; \
+				poetry publish --build --username "__token__" --password "${PYPI_API_TOKEN}"; \
 				echo "Published!"; \
 			fi \
 		else \

--- a/poetry.lock
+++ b/poetry.lock
@@ -1028,7 +1028,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "6aaec0a65b1f78764824e096fd7d8527f3b01ac73954760e29c878691ddd4801"
+content-hash = "320b7f54e8bb1ca5c597c7a77fc29d2ca8e9c2ec2fa3f8551a9088d0c186a199"
 
 [metadata.files]
 antlr4-python3-runtime = [


### PR DESCRIPTION
Fixes some issues with makefile:
- Adds Poetry environment variables to PATH after installation
- Loads in environment variables properly in the `install` target
- Prints info related to fixing the GPG bug
- Removed irrelevant `remove-env` and `clean` targets