### PR TITLE
Feat/evaluator

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -220,7 +220,7 @@ packaging = "*"
 
 [[package]]
 name = "identify"
-version = "2.5.2"
+version = "2.5.3"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -629,7 +629,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "scikit-learn"
-version = "1.1.1"
+version = "1.1.2"
 description = "A set of python modules for machine learning and data mining"
 category = "main"
 optional = false
@@ -642,10 +642,10 @@ scipy = ">=1.3.2"
 threadpoolctl = ">=2.0.0"
 
 [package.extras]
-benchmark = ["matplotlib (>=3.1.2)", "pandas (>=1.0.5)", "memory-profiler (>=0.57.0)"]
-docs = ["matplotlib (>=3.1.2)", "scikit-image (>=0.14.5)", "pandas (>=1.0.5)", "seaborn (>=0.9.0)", "memory-profiler (>=0.57.0)", "sphinx (>=4.0.1)", "sphinx-gallery (>=0.7.0)", "numpydoc (>=1.2.0)", "Pillow (>=7.1.2)", "sphinx-prompt (>=1.3.0)", "sphinxext-opengraph (>=0.4.2)"]
-examples = ["matplotlib (>=3.1.2)", "scikit-image (>=0.14.5)", "pandas (>=1.0.5)", "seaborn (>=0.9.0)"]
-tests = ["matplotlib (>=3.1.2)", "scikit-image (>=0.14.5)", "pandas (>=1.0.5)", "pytest (>=5.0.1)", "pytest-cov (>=2.9.0)", "flake8 (>=3.8.2)", "black (>=22.3.0)", "mypy (>=0.770)", "pyamg (>=4.0.0)", "numpydoc (>=1.2.0)"]
+tests = ["numpydoc (>=1.2.0)", "pyamg (>=4.0.0)", "mypy (>=0.961)", "black (>=22.3.0)", "flake8 (>=3.8.2)", "pytest-cov (>=2.9.0)", "pytest (>=5.0.1)", "pandas (>=1.0.5)", "scikit-image (>=0.16.2)", "matplotlib (>=3.1.2)"]
+examples = ["seaborn (>=0.9.0)", "pandas (>=1.0.5)", "scikit-image (>=0.16.2)", "matplotlib (>=3.1.2)"]
+docs = ["sphinxext-opengraph (>=0.4.2)", "sphinx-prompt (>=1.3.0)", "Pillow (>=7.1.2)", "numpydoc (>=1.2.0)", "sphinx-gallery (>=0.7.0)", "sphinx (>=4.0.1)", "memory-profiler (>=0.57.0)", "seaborn (>=0.9.0)", "pandas (>=1.0.5)", "scikit-image (>=0.16.2)", "matplotlib (>=3.1.2)"]
+benchmark = ["memory-profiler (>=0.57.0)", "pandas (>=1.0.5)", "matplotlib (>=3.1.2)"]
 
 [[package]]
 name = "scipy"
@@ -660,7 +660,7 @@ numpy = ">=1.18.5,<1.25.0"
 
 [[package]]
 name = "sentencepiece"
-version = "0.1.96"
+version = "0.1.97"
 description = "SentencePiece python wrapper"
 category = "main"
 optional = false
@@ -863,7 +863,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "torch"
-version = "1.12.0"
+version = "1.12.1"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
 category = "main"
 optional = false
@@ -891,7 +891,7 @@ telegram = ["requests"]
 
 [[package]]
 name = "transformers"
-version = "4.21.0"
+version = "4.21.1"
 description = "State-of-the-art Machine Learning for JAX, PyTorch and TensorFlow"
 category = "main"
 optional = false
@@ -909,7 +909,6 @@ tokenizers = ">=0.11.1,<0.11.3 || >0.11.3,<0.13"
 tqdm = ">=4.27"
 
 [package.extras]
-dev-torch = ["torchaudio", "librosa", "pytest", "pytest-xdist", "timeout-decorator", "parameterized", "psutil", "datasets", "dill (<0.3.5)", "pytest-timeout", "black (==22.3)", "sacrebleu (>=1.4.12,<2.0.0)", "rouge-score", "nltk", "GitPython (<3.1.19)", "hf-doc-builder (>=0.3.0)", "protobuf (<=3.20.1)", "sacremoses", "rjieba", "faiss-cpu", "cookiecutter (==1.7.3)", "torch (>=1.0,<1.12)", "sentencepiece (>=0.1.91,!=0.1.92)", "tokenizers (>=0.11.1,!=0.11.3,<0.13)", "pyctcdecode (>=0.3.0)", "phonemizer", "resampy (<0.3.1)", "pillow", "optuna", "ray", "sigopt", "timm", "codecarbon (==1.2.0)", "isort (>=5.5.4)", "flake8 (>=3.8.3)", "fugashi (>=1.0)", "ipadic (>=1.0.0,<2.0)", "unidic-lite (>=1.0.7)", "unidic (>=1.0.2)", "hf-doc-builder", "scikit-learn", "onnxruntime (>=1.4.0)", "onnxruntime-tools (>=1.4.2)"]
 accelerate = ["accelerate (>=0.10.0)"]
 all = ["tensorflow (>=2.3)", "onnxconverter-common", "tf2onnx", "tensorflow-text", "torch (>=1.0,<1.12)", "jax (>=0.2.8,!=0.3.2,<=0.3.6)", "jaxlib (>=0.1.65,<=0.3.6)", "flax (>=0.4.1)", "optax (>=0.0.8)", "sentencepiece (>=0.1.91,!=0.1.92)", "protobuf (<=3.20.1)", "tokenizers (>=0.11.1,!=0.11.3,<0.13)", "torchaudio", "librosa", "pyctcdecode (>=0.3.0)", "phonemizer", "resampy (<0.3.1)", "pillow", "optuna", "ray", "sigopt", "timm", "codecarbon (==1.2.0)", "accelerate (>=0.10.0)"]
 audio = ["librosa", "pyctcdecode (>=0.3.0)", "phonemizer", "resampy (<0.3.1)"]
@@ -918,6 +917,7 @@ deepspeed = ["deepspeed (>=0.6.5)", "accelerate (>=0.10.0)"]
 deepspeed-testing = ["deepspeed (>=0.6.5)", "accelerate (>=0.10.0)", "pytest", "pytest-xdist", "timeout-decorator", "parameterized", "psutil", "datasets", "dill (<0.3.5)", "pytest-timeout", "black (==22.3)", "sacrebleu (>=1.4.12,<2.0.0)", "rouge-score", "nltk", "GitPython (<3.1.19)", "hf-doc-builder (>=0.3.0)", "protobuf (<=3.20.1)", "sacremoses", "rjieba", "faiss-cpu", "cookiecutter (==1.7.3)", "optuna"]
 dev = ["tensorflow (>=2.3)", "onnxconverter-common", "tf2onnx", "tensorflow-text", "torch (>=1.0,<1.12)", "jax (>=0.2.8,!=0.3.2,<=0.3.6)", "jaxlib (>=0.1.65,<=0.3.6)", "flax (>=0.4.1)", "optax (>=0.0.8)", "sentencepiece (>=0.1.91,!=0.1.92)", "protobuf (<=3.20.1)", "tokenizers (>=0.11.1,!=0.11.3,<0.13)", "torchaudio", "librosa", "pyctcdecode (>=0.3.0)", "phonemizer", "resampy (<0.3.1)", "pillow", "optuna", "ray", "sigopt", "timm", "codecarbon (==1.2.0)", "accelerate (>=0.10.0)", "pytest", "pytest-xdist", "timeout-decorator", "parameterized", "psutil", "datasets", "dill (<0.3.5)", "pytest-timeout", "black (==22.3)", "sacrebleu (>=1.4.12,<2.0.0)", "rouge-score", "nltk", "GitPython (<3.1.19)", "hf-doc-builder (>=0.3.0)", "sacremoses", "rjieba", "faiss-cpu", "cookiecutter (==1.7.3)", "isort (>=5.5.4)", "flake8 (>=3.8.3)", "fugashi (>=1.0)", "ipadic (>=1.0.0,<2.0)", "unidic-lite (>=1.0.7)", "unidic (>=1.0.2)", "hf-doc-builder", "scikit-learn"]
 dev-tensorflow = ["pytest", "pytest-xdist", "timeout-decorator", "parameterized", "psutil", "datasets", "dill (<0.3.5)", "pytest-timeout", "black (==22.3)", "sacrebleu (>=1.4.12,<2.0.0)", "rouge-score", "nltk", "GitPython (<3.1.19)", "hf-doc-builder (>=0.3.0)", "protobuf (<=3.20.1)", "sacremoses", "rjieba", "faiss-cpu", "cookiecutter (==1.7.3)", "tensorflow (>=2.3)", "onnxconverter-common", "tf2onnx", "tensorflow-text", "sentencepiece (>=0.1.91,!=0.1.92)", "tokenizers (>=0.11.1,!=0.11.3,<0.13)", "pillow", "isort (>=5.5.4)", "flake8 (>=3.8.3)", "hf-doc-builder", "scikit-learn", "onnxruntime (>=1.4.0)", "onnxruntime-tools (>=1.4.2)", "librosa", "pyctcdecode (>=0.3.0)", "phonemizer", "resampy (<0.3.1)"]
+dev-torch = ["pytest", "pytest-xdist", "timeout-decorator", "parameterized", "psutil", "datasets", "dill (<0.3.5)", "pytest-timeout", "black (==22.3)", "sacrebleu (>=1.4.12,<2.0.0)", "rouge-score", "nltk", "GitPython (<3.1.19)", "hf-doc-builder (>=0.3.0)", "protobuf (<=3.20.1)", "sacremoses", "rjieba", "faiss-cpu", "cookiecutter (==1.7.3)", "torch (>=1.0,<1.12)", "sentencepiece (>=0.1.91,!=0.1.92)", "tokenizers (>=0.11.1,!=0.11.3,<0.13)", "torchaudio", "librosa", "pyctcdecode (>=0.3.0)", "phonemizer", "resampy (<0.3.1)", "pillow", "optuna", "ray", "sigopt", "timm", "codecarbon (==1.2.0)", "isort (>=5.5.4)", "flake8 (>=3.8.3)", "fugashi (>=1.0)", "ipadic (>=1.0.0,<2.0)", "unidic-lite (>=1.0.7)", "unidic (>=1.0.2)", "hf-doc-builder", "scikit-learn", "onnxruntime (>=1.4.0)", "onnxruntime-tools (>=1.4.2)"]
 docs = ["tensorflow (>=2.3)", "onnxconverter-common", "tf2onnx", "tensorflow-text", "torch (>=1.0,<1.12)", "jax (>=0.2.8,!=0.3.2,<=0.3.6)", "jaxlib (>=0.1.65,<=0.3.6)", "flax (>=0.4.1)", "optax (>=0.0.8)", "sentencepiece (>=0.1.91,!=0.1.92)", "protobuf (<=3.20.1)", "tokenizers (>=0.11.1,!=0.11.3,<0.13)", "torchaudio", "librosa", "pyctcdecode (>=0.3.0)", "phonemizer", "resampy (<0.3.1)", "pillow", "optuna", "ray", "sigopt", "timm", "codecarbon (==1.2.0)", "accelerate (>=0.10.0)", "hf-doc-builder"]
 docs_specific = ["hf-doc-builder"]
 fairscale = ["fairscale (>0.3)"]
@@ -990,20 +990,20 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.16.2"
+version = "20.16.3"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-distlib = ">=0.3.1,<1"
-filelock = ">=3.2,<4"
-platformdirs = ">=2,<3"
+distlib = ">=0.3.5,<1"
+filelock = ">=3.4.1,<4"
+platformdirs = ">=2.4,<3"
 
 [package.extras]
-docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
-testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "packaging (>=20.0)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)"]
+docs = ["proselint (>=0.13)", "sphinx (>=5.1.1)", "sphinx-argparse (>=0.3.1)", "sphinx-rtd-theme (>=1)", "towncrier (>=21.9)"]
+testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=21.3)", "pytest (>=7.0.1)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.6.1)", "pytest-randomly (>=3.10.3)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "wasabi"
@@ -1147,8 +1147,8 @@ hydra-core = [
     {file = "hydra_core-1.2.0-py3-none-any.whl", hash = "sha256:b6614fd6d6a97a9499f7ddbef02c9dd38f2fec6a9bc83c10e248db1dae50a528"},
 ]
 identify = [
-    {file = "identify-2.5.2-py2.py3-none-any.whl", hash = "sha256:feaa9db2dc0ce333b453ce171c0cf1247bbfde2c55fc6bb785022d411a1b78b5"},
-    {file = "identify-2.5.2.tar.gz", hash = "sha256:a3d4c096b384d50d5e6dc5bc8b9bc44f1f61cefebd750a7b3e9f939b53fb214d"},
+    {file = "identify-2.5.3-py2.py3-none-any.whl", hash = "sha256:25851c8c1370effb22aaa3c987b30449e9ff0cece408f810ae6ce408fdd20893"},
+    {file = "identify-2.5.3.tar.gz", hash = "sha256:887e7b91a1be152b0d46bbf072130235a8117392b9f1828446079a816a05ef44"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -1486,24 +1486,24 @@ requests = [
     {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
 ]
 scikit-learn = [
-    {file = "scikit-learn-1.1.1.tar.gz", hash = "sha256:3e77b71e8e644f86c8b5be7f1c285ef597de4c384961389ee3e9ca36c445b256"},
-    {file = "scikit_learn-1.1.1-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:102f51797cd8944bf44a038d106848ddf2804f2c1edf7aea45fba81a4fdc4d80"},
-    {file = "scikit_learn-1.1.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:723cdb278b1fa57a55f68945bc4e501a2f12abe82f76e8d21e1806cbdbef6fc5"},
-    {file = "scikit_learn-1.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:33cf061ed0b79d647a3e4c3f6c52c412172836718a7cd4d11c1318d083300133"},
-    {file = "scikit_learn-1.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47464c110eaa9ed9d1fe108cb403510878c3d3a40f110618d2a19b2190a3e35c"},
-    {file = "scikit_learn-1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:542ccd2592fe7ad31f5c85fed3a3deb3e252383960a85e4b49a629353fffaba4"},
-    {file = "scikit_learn-1.1.1-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:3be10d8d325821ca366d4fe7083d87c40768f842f54371a9c908d97c45da16fc"},
-    {file = "scikit_learn-1.1.1-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:b2db720e13e697d912a87c1a51194e6fb085dc6d8323caa5ca51369ca6948f78"},
-    {file = "scikit_learn-1.1.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e851f8874398dcd50d1e174e810e9331563d189356e945b3271c0e19ee6f4d6f"},
-    {file = "scikit_learn-1.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b928869072366dc138762fe0929e7dc88413f8a469aebc6a64adc10a9226180c"},
-    {file = "scikit_learn-1.1.1-cp38-cp38-win32.whl", hash = "sha256:e9d228ced1214d67904f26fb820c8abbea12b2889cd4aa8cda20a4ca0ed781c1"},
-    {file = "scikit_learn-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:f2d5b5d6e87d482e17696a7bfa03fe9515fdfe27e462a4ad37f3d7774a5e2fd6"},
-    {file = "scikit_learn-1.1.1-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:0403ad13f283e27d43b0ad875f187ec7f5d964903d92d1ed06c51439560ecea0"},
-    {file = "scikit_learn-1.1.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:8fe80df08f5b9cee5dd008eccc672e543976198d790c07e5337f7dfb67eaac05"},
-    {file = "scikit_learn-1.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8ff56d07b9507fbe07ca0f4e5c8f3e171f74a429f998da03e308166251316b34"},
-    {file = "scikit_learn-1.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c2dad2bfc502344b869d4a3f4aa7271b2a5f4fe41f7328f404844c51612e2c58"},
-    {file = "scikit_learn-1.1.1-cp39-cp39-win32.whl", hash = "sha256:22145b60fef02e597a8e7f061ebc7c51739215f11ce7fcd2ca9af22c31aa9f86"},
-    {file = "scikit_learn-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:45c0f6ae523353f1d99b85469d746f9c497410adff5ba8b24423705b6956a86e"},
+    {file = "scikit-learn-1.1.2.tar.gz", hash = "sha256:7c22d1305b16f08d57751a4ea36071e2215efb4c09cb79183faa4e8e82a3dbf8"},
+    {file = "scikit_learn-1.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6c840f662b5d3377c4ccb8be1fc21bb52cb5d8b8790f8d6bf021739f84e543cf"},
+    {file = "scikit_learn-1.1.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:2b8db962360c93554cab7bb3c096c4a24695da394dd4b3c3f13409f409b425bc"},
+    {file = "scikit_learn-1.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e7d1fc817867a350133f937aaebcafbc06192517cbdf0cf7e5774ad4d1adb9f"},
+    {file = "scikit_learn-1.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ec3ea40d467966821843210c02117d82b097b54276fdcfb50f4dfb5c60dbe39"},
+    {file = "scikit_learn-1.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:bbef6ea1c012ff9f3e6f6e9ca006b8772d8383e177b898091e68fbd9b3f840f9"},
+    {file = "scikit_learn-1.1.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a90ca42fe8242fd6ff56cda2fecc5fca586a88a24ab602d275d2d0dcc0b928fb"},
+    {file = "scikit_learn-1.1.2-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:a682ec0f82b6f30fb07486daed1c8001b6683cc66b51877644dfc532bece6a18"},
+    {file = "scikit_learn-1.1.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c33e16e9a165af6012f5be530ccfbb672e2bc5f9b840238a05eb7f6694304e3f"},
+    {file = "scikit_learn-1.1.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f94c0146bad51daef919c402a3da8c1c6162619653e1c00c92baa168fda292f2"},
+    {file = "scikit_learn-1.1.2-cp38-cp38-win32.whl", hash = "sha256:2f46c6e3ff1054a5ec701646dcfd61d43b8ecac4d416014daed8843cf4c33d4d"},
+    {file = "scikit_learn-1.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:b1e706deca9b2ad87ae27dafd5ac4e8eff01b6db492ed5c12cef4735ec5f21ea"},
+    {file = "scikit_learn-1.1.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:567417dbbe6a6278399c3e6daf1654414a5a1a4d818d28f251fa7fc28730a1bf"},
+    {file = "scikit_learn-1.1.2-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:d6f232779023c3b060b80b5c82e5823723bc424dcac1d1a148aa2492c54d245d"},
+    {file = "scikit_learn-1.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:589d46f28460469f444b898223b13d99db9463e1038dc581ba698111f612264b"},
+    {file = "scikit_learn-1.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76800652fb6d6bf527bce36ecc2cc25738b28fe1a17bd294a218fff8e8bd6d50"},
+    {file = "scikit_learn-1.1.2-cp39-cp39-win32.whl", hash = "sha256:1c8fecb7c9984d9ec2ea48898229f98aad681a0873e0935f2b7f724fbce4a047"},
+    {file = "scikit_learn-1.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:407e9a1cb9e6ba458a539986a9bd25546a757088095b3aab91d465b79a760d37"},
 ]
 scipy = [
     {file = "scipy-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0424d1bbbfa51d5ddaa16d067fd593863c9f2fb7c6840c32f8a08a8832f8e7a4"},
@@ -1531,50 +1531,43 @@ scipy = [
     {file = "scipy-1.9.0.tar.gz", hash = "sha256:c0dfd7d2429452e7e94904c6a3af63cbaa3cf51b348bd9d35b42db7e9ad42791"},
 ]
 sentencepiece = [
-    {file = "sentencepiece-0.1.96-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc969e6694fb27fba7cee2953f350804faf03913f25ae1ee713a7b8a1bc08018"},
-    {file = "sentencepiece-0.1.96-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:36e9ff61e7b67c5b7ee96733613622620b4802fc8cf188a4dbc1f355b03dde02"},
-    {file = "sentencepiece-0.1.96-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e9e9fe8094ca57549d801e9a2017ac5c24108bbf485ea4f8994a72e8e96ee135"},
-    {file = "sentencepiece-0.1.96-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b77d27f59d515c43b61745b8173fbe7c7b3014b14b3702a75bf1793471e7def6"},
-    {file = "sentencepiece-0.1.96-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1dac8c2ad02b5ebc1179c0a14cbc7d7c6f4fd73d4dd51820626402d0aefc974e"},
-    {file = "sentencepiece-0.1.96-cp310-cp310-win32.whl", hash = "sha256:3028699bdb2fb0230804f3b8a617fe3af22f5c5a56416419b31a7da5e7bf83bc"},
-    {file = "sentencepiece-0.1.96-cp310-cp310-win_amd64.whl", hash = "sha256:203443a7bd4295b6a3695787235abe0e77d4c369d7156a6b9a397c540a38bd27"},
-    {file = "sentencepiece-0.1.96-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:e8ec5bb6777e2060e1499750c50e1b69dca5a0f80f90f2c66656c5f3e5244593"},
-    {file = "sentencepiece-0.1.96-cp36-cp36m-macosx_10_6_x86_64.whl", hash = "sha256:99ea2d9db19e63a2d17d5dc64f9ace83fb9308a735be05a1aaf98eb4b496fba7"},
-    {file = "sentencepiece-0.1.96-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aeb090ad462833df03af1debce4ae607a2766ef861f992003ad0c56d074ab805"},
-    {file = "sentencepiece-0.1.96-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f8c90df663cd9759b2cf8dd29998b63140ac39e51ada2e739dc13bdac0b4f001"},
-    {file = "sentencepiece-0.1.96-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26d20d713b3ba1b7a19205336afb1e93a4327c372b2f795e907b8dc2315ac92e"},
-    {file = "sentencepiece-0.1.96-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5388882bb24d083f6cc8cffc5c435f3694a7772b018e06ea6fd84d1044009efb"},
-    {file = "sentencepiece-0.1.96-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a92e1932ee8fd500680ccbe1bf53eb33228f4c9d6524ed6f300bcc80ac359f27"},
-    {file = "sentencepiece-0.1.96-cp36-cp36m-win32.whl", hash = "sha256:bedf0355117fb4e9b1fc9fc92b4d5ee743a7d468be9f6196e3b94447710ea589"},
-    {file = "sentencepiece-0.1.96-cp36-cp36m-win_amd64.whl", hash = "sha256:4997c7ccf2ae462320250314aa5709a88d8a09fa271d073458a07bebf33f8e7c"},
-    {file = "sentencepiece-0.1.96-cp37-cp37m-macosx_10_6_x86_64.whl", hash = "sha256:a697257a2cd7581732d7741a8d32a06927f0311c3d277dbc47fa1043350c9d17"},
-    {file = "sentencepiece-0.1.96-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff7d752a7f82d87711ec1a95c2262cb74f98be5b457f0300d81a1aefe5be2a95"},
-    {file = "sentencepiece-0.1.96-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3e61e0757e49c306fff78ea75d6b75773418fe22214b4a460959203be934e834"},
-    {file = "sentencepiece-0.1.96-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ef59ba19340dc1d002ce5713b911c0ef23c577b08f8ed57998ee3c8e62c5bf6e"},
-    {file = "sentencepiece-0.1.96-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:89c038da7f827a6e2ca4c73aeb4e4b25b99d981ce47dd61b04d446c8200cba1e"},
-    {file = "sentencepiece-0.1.96-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d954d25a8705f972e8bfc1dea5464d7e697dd6f4ade092f1a487387e6d6c829a"},
-    {file = "sentencepiece-0.1.96-cp37-cp37m-win32.whl", hash = "sha256:fd907a8f744e5337de7fc532dd800c4416b571ea47f8c3c66be10cd1bc67c925"},
-    {file = "sentencepiece-0.1.96-cp37-cp37m-win_amd64.whl", hash = "sha256:335bf84d72112cc91f3c3b691d61802fc963503b7772fd8280d20368048b8f3e"},
-    {file = "sentencepiece-0.1.96-cp38-cp38-macosx_10_6_x86_64.whl", hash = "sha256:e811984b0908c14c56de7d8226fdd494d87a7ccb75af8ac3a07423037aaafc35"},
-    {file = "sentencepiece-0.1.96-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8179785883b556cd517416cdbda6244745414b00ec83132cfe1d26000971f3ae"},
-    {file = "sentencepiece-0.1.96-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:466e381f0a812da8fda97a9707498cef3210ea8385a3421bcbadcb5384063969"},
-    {file = "sentencepiece-0.1.96-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8cb24d8d0b2f8b7463815a59183eb81ec1d7a06e3217bed456063f3303eddfb"},
-    {file = "sentencepiece-0.1.96-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e88354b61f59dfdeb41023f7be8ae31dc627c2dc2dacbc2de8b2d82a0997135c"},
-    {file = "sentencepiece-0.1.96-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a336575463d75d3aac1f7e32470b8998643ccd9a73786bd726f6b0470520b6b4"},
-    {file = "sentencepiece-0.1.96-cp38-cp38-win32.whl", hash = "sha256:81bb77ba3651114943b2f8f77829cf764137dff06e38f4bf7fa43efea12c7f84"},
-    {file = "sentencepiece-0.1.96-cp38-cp38-win_amd64.whl", hash = "sha256:eba0471ab0bb2e07ed06d91ecf5185d402c83d194155a41d8e2aa547d187712e"},
-    {file = "sentencepiece-0.1.96-cp39-cp39-macosx_10_6_x86_64.whl", hash = "sha256:78e18d9106c36dcca929e18fd2c412378deac661d47fa3ee25defc55eef8a215"},
-    {file = "sentencepiece-0.1.96-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1c24c1d9405b2148184ff27c062493d5e3be5c144575f95b5a0d7c660a515af"},
-    {file = "sentencepiece-0.1.96-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:940a6999c7d3f55e9d7b194fd5e1f41a7dbed26d3519fb95333216292a39599e"},
-    {file = "sentencepiece-0.1.96-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:384148cead5cdab34a4d74fe1fb6a5a8abaafed25eaa4a7698b49dd9482e4c4e"},
-    {file = "sentencepiece-0.1.96-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3c703e68ea192e45b65c5d5836f6980849d828a18da4189899d7150fad82dc9e"},
-    {file = "sentencepiece-0.1.96-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d501713a8396193883aa526f48dc609f5f031a5df1afbafa561cf9ab492ffc76"},
-    {file = "sentencepiece-0.1.96-cp39-cp39-win32.whl", hash = "sha256:b8b1dd2712f8a7de5b4c8ec912e6c041d25750bf03e1ce325cdba43bae0944ae"},
-    {file = "sentencepiece-0.1.96-cp39-cp39-win_amd64.whl", hash = "sha256:d45e3f78e746aa161bc9f5a31c6a2839c512101113a4065f4d2e7a3ab8198d8c"},
-    {file = "sentencepiece-0.1.96-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5513298d62fe63dd0862d08a6eb52a9aa3537006f597f2386184e3f95bb88889"},
-    {file = "sentencepiece-0.1.96-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dadccb2e49244b6e64b4527d13ec14d5e094a90b41cf9b963e457e64182f1941"},
-    {file = "sentencepiece-0.1.96-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48c6d13b3bfff08060c138248e85df60f6fad11135ad7a8fc2ef6005aacca839"},
-    {file = "sentencepiece-0.1.96.tar.gz", hash = "sha256:9bdf097d5bd1d8ce42dfee51f6ff05f5578b96e48c6f6006aa4eff69edfa3639"},
+    {file = "sentencepiece-0.1.97-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6f249c8f1852893be86eae66b19d522c5fb30bbad4fe2d1b07f06fdc86e1907e"},
+    {file = "sentencepiece-0.1.97-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:09e1bc53178de70c557a9ba4fece07364b4416ce3d36570726b3372b68aea135"},
+    {file = "sentencepiece-0.1.97-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:667193c57fb48b238be7e3d7636cfc8da56cb5bac5559d8f0b647334e1175be8"},
+    {file = "sentencepiece-0.1.97-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2780531985af79c6163f63d4f200fec8a28b70b6768d2c19f70d01568a4524e8"},
+    {file = "sentencepiece-0.1.97-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:205050670c53ef9015e2a98cce3934bfbcf0aafaa14caa0c618dd5667bc217ee"},
+    {file = "sentencepiece-0.1.97-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b183dadef8e8b6b4645c1c20692d7be0a13ecc3ec1a07b3885c8905516675f"},
+    {file = "sentencepiece-0.1.97-cp310-cp310-win32.whl", hash = "sha256:ee3c9dbd558d8d85bb1617087b86df6ea2b856a528669630ce6cedeb4353b823"},
+    {file = "sentencepiece-0.1.97-cp310-cp310-win_amd64.whl", hash = "sha256:f7dc55379e2f7dee86537180283db2e5f8418c6825fdd2fe436c724eb5604c05"},
+    {file = "sentencepiece-0.1.97-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ba1b4154f9144c5a7528b00aff5cffaa1a896a1c6ca53ca78b6e74cd2dae5244"},
+    {file = "sentencepiece-0.1.97-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac3d90aee5581e55d029d124ac11b6ae2fbae0817863b664b2f2302e966ababb"},
+    {file = "sentencepiece-0.1.97-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1c27400f1ac46518a01c87cb7703650e4e48728649feb115d2e3f1102a946a42"},
+    {file = "sentencepiece-0.1.97-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6e12a166eba75994ca749aadc4a5056b91b31405f805d6de6e8914cc9741c60"},
+    {file = "sentencepiece-0.1.97-cp36-cp36m-win32.whl", hash = "sha256:ed85dff5c0a9b3dd1a414c7e1119f2a19e863fc3f81da525bf7f885ebc883de0"},
+    {file = "sentencepiece-0.1.97-cp36-cp36m-win_amd64.whl", hash = "sha256:91a19ab6f40ffbae6d6127119953d2c6a85e93d734953dbc8629fde0d21ace66"},
+    {file = "sentencepiece-0.1.97-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bae580e4a35a9314ff49561ac7c06574fe6afc71b821ed6bb00534e571458156"},
+    {file = "sentencepiece-0.1.97-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ad7262e7530c683b186672b5dd0082f82719a50a500a8cfbc4bbd7cde5bff8c"},
+    {file = "sentencepiece-0.1.97-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:620cee35279720016735a7c7103cddbd9b84fe5e2f098bd5e673834d69fee2b8"},
+    {file = "sentencepiece-0.1.97-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:93b921b59914c0ec6697e8c6d5e6b44d99d1298fb1a0af56980a79ade0540c19"},
+    {file = "sentencepiece-0.1.97-cp37-cp37m-win32.whl", hash = "sha256:9b9a4c44a31d5f47616e9568dcf31e029b0bfa776e0a252c0b59247881598b09"},
+    {file = "sentencepiece-0.1.97-cp37-cp37m-win_amd64.whl", hash = "sha256:f31533cdacced56219e239d3459a003ece35116920dd64b2309d4ad047b77644"},
+    {file = "sentencepiece-0.1.97-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:7d643c01d1cad13b9206a276bbe5bc1a468e3d7cf6a26bde7783f945277f859d"},
+    {file = "sentencepiece-0.1.97-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:542f1985b1ee279a92bef7740ec0781452372028ce01e15aa88df3228b197ba3"},
+    {file = "sentencepiece-0.1.97-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:93701da21fea906dd244bf88cdbe640385a89c45d3c1812b76dbadf8782cdbcd"},
+    {file = "sentencepiece-0.1.97-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a51514047b964047b7fadb480d88a5e0f72c02f6ca1ba96258fbbc6e79274a94"},
+    {file = "sentencepiece-0.1.97-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e3ae2e9b7a5b6f2aa64ec9240b0c185dabe597d0e787dc4344acfbaef1ffe0b2"},
+    {file = "sentencepiece-0.1.97-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:923ee4af16dbae1f2ab358ed09f8a0eb89e40a8198a8b343bf54181482342721"},
+    {file = "sentencepiece-0.1.97-cp38-cp38-win32.whl", hash = "sha256:fa6f2b88850b5fae3a05053658824cf9f147c8e3c3b40eb64539a976c83d8a24"},
+    {file = "sentencepiece-0.1.97-cp38-cp38-win_amd64.whl", hash = "sha256:5137ff0d0b1cc574751d178650ef800ff8d90bf21eb9f71e9567d4a0548940a5"},
+    {file = "sentencepiece-0.1.97-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:f92876271a10494671431ad955bff2d6f8ea59baaf957f5ae5946aff56dfcb90"},
+    {file = "sentencepiece-0.1.97-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:35c227b6d55e473033db7e0ecc51b1e99e6ed7607cc08602fb5768132543c81d"},
+    {file = "sentencepiece-0.1.97-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1706a8a8188f7b3d4b7922db9bb00c64c4e16ee68ab4caaae79f55b3e18748c7"},
+    {file = "sentencepiece-0.1.97-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce61efc1862ccb18856c4aabbd930e13d5bfbb4b09b4f111081ac53a9dc62275"},
+    {file = "sentencepiece-0.1.97-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a78c03800ef9f02d320e0159f5768b15357f3e9ebea545c9c4ba7928ba8ba254"},
+    {file = "sentencepiece-0.1.97-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:753b8088fd685ee787d9f54c84275ab347de558c7c4ebc6accb4c35bf7776f20"},
+    {file = "sentencepiece-0.1.97-cp39-cp39-win32.whl", hash = "sha256:24306fd86031c17a1a6ae92671e76a350390a3140a65620bc2843dad7db24e2a"},
+    {file = "sentencepiece-0.1.97-cp39-cp39-win_amd64.whl", hash = "sha256:c6641d0b7acec61fde5881ea6ebe098c169557ac9aa3bdabdf124eab5a5592bb"},
+    {file = "sentencepiece-0.1.97.tar.gz", hash = "sha256:c901305e0a710bbcd296f66d79e96f744e6e175b29812bd5178318437d4e1f6c"},
 ]
 seqeval = [
     {file = "seqeval-1.2.2.tar.gz", hash = "sha256:f28e97c3ab96d6fcd32b648f6438ff2e09cfba87f05939da9b3970713ec56e6f"},
@@ -1721,34 +1714,34 @@ tomli = [
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 torch = [
-    {file = "torch-1.12.0-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:3322d33a06e440d715bb214334bd41314c94632d9a2f07d22006bf21da3a2be4"},
-    {file = "torch-1.12.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:2568f011dddeb5990d8698cc375d237f14568ffa8489854e3b94113b4b6b7c8b"},
-    {file = "torch-1.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:e3e8348edca3e3cee5a67a2b452b85c57712efe1cc3ffdb87c128b3dde54534e"},
-    {file = "torch-1.12.0-cp310-none-macosx_10_9_x86_64.whl", hash = "sha256:349ea3ba0c0e789e0507876c023181f13b35307aebc2e771efd0e045b8e03e84"},
-    {file = "torch-1.12.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:13c7cca6b2ea3704d775444f02af53c5f072d145247e17b8cd7813ac57869f03"},
-    {file = "torch-1.12.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:60d06ee2abfa85f10582d205404d52889d69bcbb71f7e211cfc37e3957ac19ca"},
-    {file = "torch-1.12.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:a1325c9c28823af497cbf443369bddac9ac59f67f1e600f8ab9b754958e55b76"},
-    {file = "torch-1.12.0-cp37-cp37m-win_amd64.whl", hash = "sha256:fb47291596677570246d723ee6abbcbac07eeba89d8f83de31e3954f21f44879"},
-    {file = "torch-1.12.0-cp37-none-macosx_10_9_x86_64.whl", hash = "sha256:abbdc5483359b9495dc76e3bd7911ccd2ddc57706c117f8316832e31590af871"},
-    {file = "torch-1.12.0-cp37-none-macosx_11_0_arm64.whl", hash = "sha256:72207b8733523388c49d43ffcc4416d1d8cd64c40f7826332e714605ace9b1d2"},
-    {file = "torch-1.12.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0986685f2ec8b7c4d3593e8cfe96be85d462943f1a8f54112fc48d4d9fbbe903"},
-    {file = "torch-1.12.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:0399746f83b4541bcb5b219a18dbe8cade760aba1c660d2748a38c6dc338ebc7"},
-    {file = "torch-1.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:7ddb167827170c4e3ff6a27157414a00b9fef93dea175da04caf92a0619b7aee"},
-    {file = "torch-1.12.0-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:2143d5fe192fd908b70b494349de5b1ac02854a8a902bd5f47d13d85b410e430"},
-    {file = "torch-1.12.0-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:44a3804e9bb189574f5d02ccc2dc6e32e26a81b3e095463b7067b786048c6072"},
-    {file = "torch-1.12.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:844f1db41173b53fe40c44b3e04fcca23a6ce00ac328b7099f2800e611766845"},
-    {file = "torch-1.12.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:63341f96840a223f277e498d2737b39da30d9f57c7a1ef88857b920096317739"},
-    {file = "torch-1.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:201abf43a99bb4980cc827dd4b38ac28f35e4dddac7832718be3d5479cafd2c1"},
-    {file = "torch-1.12.0-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:c0313438bc36448ffd209f5fb4e5f325b3af158cdf61c8829b8ddaf128c57816"},
-    {file = "torch-1.12.0-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:5ed69d5af232c5c3287d44cef998880dadcc9721cd020e9ae02f42e56b79c2e4"},
+    {file = "torch-1.12.1-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:9c038662db894a23e49e385df13d47b2a777ffd56d9bcd5b832593fab0a7e286"},
+    {file = "torch-1.12.1-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:4e1b9c14cf13fd2ab8d769529050629a0e68a6fc5cb8e84b4a3cc1dd8c4fe541"},
+    {file = "torch-1.12.1-cp310-cp310-win_amd64.whl", hash = "sha256:e9c8f4a311ac29fc7e8e955cfb7733deb5dbe1bdaabf5d4af2765695824b7e0d"},
+    {file = "torch-1.12.1-cp310-none-macosx_10_9_x86_64.whl", hash = "sha256:976c3f997cea38ee91a0dd3c3a42322785414748d1761ef926b789dfa97c6134"},
+    {file = "torch-1.12.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:68104e4715a55c4bb29a85c6a8d57d820e0757da363be1ba680fa8cc5be17b52"},
+    {file = "torch-1.12.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:743784ccea0dc8f2a3fe6a536bec8c4763bd82c1352f314937cb4008d4805de1"},
+    {file = "torch-1.12.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b5dbcca369800ce99ba7ae6dee3466607a66958afca3b740690d88168752abcf"},
+    {file = "torch-1.12.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f3b52a634e62821e747e872084ab32fbcb01b7fa7dbb7471b6218279f02a178a"},
+    {file = "torch-1.12.1-cp37-none-macosx_10_9_x86_64.whl", hash = "sha256:8a34a2fbbaa07c921e1b203f59d3d6e00ed379f2b384445773bd14e328a5b6c8"},
+    {file = "torch-1.12.1-cp37-none-macosx_11_0_arm64.whl", hash = "sha256:42f639501928caabb9d1d55ddd17f07cd694de146686c24489ab8c615c2871f2"},
+    {file = "torch-1.12.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0b44601ec56f7dd44ad8afc00846051162ef9c26a8579dda0a02194327f2d55e"},
+    {file = "torch-1.12.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:cd26d8c5640c3a28c526d41ccdca14cf1cbca0d0f2e14e8263a7ac17194ab1d2"},
+    {file = "torch-1.12.1-cp38-cp38-win_amd64.whl", hash = "sha256:42e115dab26f60c29e298559dbec88444175528b729ae994ec4c65d56fe267dd"},
+    {file = "torch-1.12.1-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:a8320ba9ad87e80ca5a6a016e46ada4d1ba0c54626e135d99b2129a4541c509d"},
+    {file = "torch-1.12.1-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:03e31c37711db2cd201e02de5826de875529e45a55631d317aadce2f1ed45aa8"},
+    {file = "torch-1.12.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:9b356aea223772cd754edb4d9ecf2a025909b8615a7668ac7d5130f86e7ec421"},
+    {file = "torch-1.12.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:6cf6f54b43c0c30335428195589bd00e764a6d27f3b9ba637aaa8c11aaf93073"},
+    {file = "torch-1.12.1-cp39-cp39-win_amd64.whl", hash = "sha256:f00c721f489089dc6364a01fd84906348fe02243d0af737f944fddb36003400d"},
+    {file = "torch-1.12.1-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:bfec2843daa654f04fda23ba823af03e7b6f7650a873cdb726752d0e3718dada"},
+    {file = "torch-1.12.1-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:69fe2cae7c39ccadd65a123793d30e0db881f1c1927945519c5c17323131437e"},
 ]
 tqdm = [
     {file = "tqdm-4.64.0-py2.py3-none-any.whl", hash = "sha256:74a2cdefe14d11442cedf3ba4e21a3b84ff9a2dbdc6cfae2c34addb2a14a5ea6"},
     {file = "tqdm-4.64.0.tar.gz", hash = "sha256:40be55d30e200777a307a7585aee69e4eabb46b4ec6a4b4a5f2d9f11e7d5408d"},
 ]
 transformers = [
-    {file = "transformers-4.21.0-py3-none-any.whl", hash = "sha256:e2eb3576aeee931ed636286ff2942f6d9ae75e0219030493479e744a4aa34653"},
-    {file = "transformers-4.21.0.tar.gz", hash = "sha256:479ee0e266ac2ac3e28c94b0697ceea2be0ea4aa1a03194930900786217bbcd8"},
+    {file = "transformers-4.21.1-py3-none-any.whl", hash = "sha256:15785eda995f53d4e98ad92e84b7446dd7cf2426ba79a1ffa7511c723bd32dfb"},
+    {file = "transformers-4.21.1.tar.gz", hash = "sha256:20f895d7304a5c7f5af099f9300b326819df9cf2167cdfb754450facc0e094f6"},
 ]
 typer = [
     {file = "typer-0.4.2-py3-none-any.whl", hash = "sha256:023bae00d1baf358a6cc7cea45851639360bb716de687b42b0a4641cd99173f1"},
@@ -1763,8 +1756,8 @@ urllib3 = [
     {file = "urllib3-1.26.11.tar.gz", hash = "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.16.2-py2.py3-none-any.whl", hash = "sha256:635b272a8e2f77cb051946f46c60a54ace3cb5e25568228bd6b57fc70eca9ff3"},
-    {file = "virtualenv-20.16.2.tar.gz", hash = "sha256:0ef5be6d07181946891f5abc8047fda8bc2f0b4b9bf222c64e6e8963baee76db"},
+    {file = "virtualenv-20.16.3-py2.py3-none-any.whl", hash = "sha256:4193b7bc8a6cd23e4eb251ac64f29b4398ab2c233531e66e40b19a6b7b0d30c1"},
+    {file = "virtualenv-20.16.3.tar.gz", hash = "sha256:d86ea0bb50e06252d79e6c241507cb904fcd66090c3271381372d6221a3970f9"},
 ]
 wasabi = [
     {file = "wasabi-0.10.1-py3-none-any.whl", hash = "sha256:fe862cc24034fbc9f04717cd312ab884f71f51a8ecabebc3449b751c2a649d83"},

--- a/src/aiai_eval/config.py
+++ b/src/aiai_eval/config.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 @dataclass
 class MetricConfig:
     """Configuration for a metric.
-    
+
     Attributes:
         name (str):
             The name of the metric.
@@ -34,7 +34,7 @@ class MetricConfig:
 @dataclass
 class Label:
     """A label in a dataset task.
-    
+
     Attributes:
         name (str):
             The name of the label.
@@ -49,7 +49,7 @@ class Label:
 @dataclass
 class DatasetTask:
     """A dataset task.
-    
+
     Attributes:
         name (str):
             The name of the task.
@@ -70,7 +70,7 @@ class DatasetTask:
 @dataclass
 class EvaluationConfig:
     """General benchmarking configuration, across datasets and models.
-    
+
     Attributes:
         model_tasks (None or sequence of str):
             The tasks of the models to benchmark.
@@ -112,7 +112,7 @@ class EvaluationConfig:
 @dataclass
 class DatasetConfig:
     """Configuration for a dataset.
-    
+
     Attributes:
         name (str):
             The name of the dataset. Must be lower case with no spaces.

--- a/src/aiai_eval/config.py
+++ b/src/aiai_eval/config.py
@@ -1,1 +1,155 @@
 """Configuration dataclasses."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+
+@dataclass
+class MetricConfig:
+    """Configuration for a metric.
+    Attributes:
+        name (str):
+            The name of the metric.
+        pretty_name (str):
+            A longer prettier name for the metric, which allows cases and spaces. Used
+            for logging.
+        huggingface_id (str):
+            The Hugging Face ID of the metric.
+        results_key (str):
+            The name of the key used to extract the metric scores from the results
+            dictionary.
+        compute_kwargs (dict, optional):
+            Keyword arguments to pass to the metric's compute function. Defaults to
+            an empty dictionary.
+    """
+
+    name: str
+    pretty_name: str
+    huggingface_id: str
+    results_key: str
+    compute_kwargs: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Label:
+    """A label in a dataset task.
+    Attributes:
+        name (str):
+            The name of the label.
+        synonyms (list of str):
+            The synonyms of the label.
+    """
+
+    name: str
+    synonyms: List[str]
+
+
+@dataclass
+class DatasetTask:
+    """A dataset task.
+    Attributes:
+        name (str):
+            The name of the task.
+        supertask (str):
+            The supertask of the task, describing the overall type of task.
+        metrics (sequence of MetricConfig objects):
+            The metrics used to evaluate the task.
+        labels (sequence of Label objects):
+            The labels used in the task.
+    """
+
+    name: str
+    supertask: str
+    metrics: Sequence[MetricConfig]
+    labels: Sequence[Label]
+
+
+@dataclass
+class EvaluationConfig:
+    """General benchmarking configuration, across datasets and models.
+    Attributes:
+        model_tasks (None or sequence of str):
+            The tasks of the models to benchmark. If None then models will not be
+            filtered according to their language.
+        dataset_tasks (sequence of DatasetTask):
+            The tasks to benchmark.
+        raise_error_on_invalid_model (bool):
+            Whether to raise an error if a model is invalid.
+        cache_dir (str):
+            Directory to store cached models and datasets.
+        evaluate_train (bool):
+            Whether to evaluate on the training set.
+        use_auth_token (bool or str):
+            The authentication token for the Hugging Face Hub. If a boolean value is
+            specified then the token will be fetched from the Hugging Face CLI, where
+            the user has logged in through `huggingface-cli login`. If a string is
+            specified then it will be used as the token. Defaults to False.
+        progress_bar (bool):
+            Whether to show a progress bar.
+        save_results (bool):
+            Whether to save the benchmark results to
+            'scandeval_benchmark_results.json'.
+        verbose (bool):
+            Whether to print verbose output.
+        testing (bool, optional):
+            Whether a unit test is being run. Defaults to False.
+    """
+
+    model_tasks: Optional[Sequence[str]]
+    dataset_tasks: Sequence[DatasetTask]
+    raise_error_on_invalid_model: bool
+    cache_dir: str
+    use_auth_token: Union[bool, str]
+    progress_bar: bool
+    save_results: bool
+    verbose: bool
+    testing: bool = False
+
+
+@dataclass
+class DatasetConfig:
+    """Configuration for a dataset.
+    Attributes:
+        name (str):
+            The name of the dataset. Must be lower case with no spaces.
+        pretty_name (str):
+            A longer prettier name for the dataset, which allows cases and spaces. Used
+            for logging.
+        huggingface_id (str):
+            The Hugging Face ID of the dataset.
+        task (DatasetTask):
+            The task of the dataset.
+        id2label (list of str):
+            The mapping from ID to label.
+        label2id (dict of str to int):
+            The mapping from label to ID. This includes all label synonyms as well.
+        num_labels (int):
+            The number of labels in the dataset.
+        label_synonyms (list of list of str):
+            The synonyms of all the labels, including the main label.
+    """
+
+    name: str
+    pretty_name: str
+    huggingface_id: str
+    task: DatasetTask
+
+    @property
+    def id2label(self) -> List[str]:
+        return [label.name for label in self.task.labels]
+
+    @property
+    def label2id(self) -> Dict[str, int]:
+        return {
+            syn: idx
+            for idx, label in enumerate(self.task.labels)
+            for syn in [label.name] + label.synonyms
+        }
+
+    @property
+    def num_labels(self) -> int:
+        return len(self.task.labels)
+
+    @property
+    def label_synonyms(self) -> List[List[str]]:
+        return [[label.name] + label.synonyms for label in self.task.labels]

--- a/src/aiai_eval/config.py
+++ b/src/aiai_eval/config.py
@@ -87,7 +87,7 @@ class EvaluationConfig:
             Whether to show a progress bar.
         save_results (bool):
             Whether to save the benchmark results to
-            'scandeval_benchmark_results.json'.
+            'evaluation_results.json'.
         verbose (bool):
             Whether to print verbose output.
         testing (bool, optional):

--- a/src/aiai_eval/config.py
+++ b/src/aiai_eval/config.py
@@ -69,8 +69,7 @@ class EvaluationConfig:
     """General benchmarking configuration, across datasets and models.
     Attributes:
         model_tasks (None or sequence of str):
-            The tasks of the models to benchmark. If None then models will not be
-            filtered according to their language.
+            The tasks of the models to benchmark.
         dataset_tasks (sequence of DatasetTask):
             The tasks to benchmark.
         raise_error_on_invalid_model (bool):

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -94,7 +94,8 @@ class Evaluator:
         model_id: Optional[Union[Sequence[str], str]] = None,
         dataset: Optional[Union[Sequence[str], str]] = None,
     ) -> Dict[str, Dict[str, dict]]:
-        """Benchmarks models on datasets.
+        """Evaluates models on datasets.
+        
         Args:
             model_id (str, list of str or None, optional):
                 The model ID(s) of the models to benchmark. If None then all relevant

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -99,9 +99,9 @@ class Evaluator:
             model_id (str, list of str or None, optional):
                 The model ID(s) of the models to benchmark. If None then all relevant
                 model IDs will be benchmarked. Defaults to None.
-            dataset (str, list of str or None, optional):
-                The datasets to benchmark on. If None then all datasets will be
-                benchmarked. Defaults to None.
+            dataset (str or list of str):
+                The dataset(s) to evaluate the model(s) on.
+                
         Returns:
             dict:
                 A nested dictionary of the benchmark results. The keys are the names of

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -97,9 +97,8 @@ class Evaluator:
         """Evaluates models on datasets.
         
         Args:
-            model_id (str, list of str or None, optional):
-                The model ID(s) of the models to benchmark. If None then all relevant
-                model IDs will be benchmarked. Defaults to None.
+            model_id (str or list of str):
+                The model ID(s) of the models to be evaluated.
             dataset (str or list of str):
                 The dataset(s) to evaluate the model(s) on.
                 

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -91,8 +91,8 @@ class Evaluator:
 
     def evaluate(
         self,
-        model_id: Optional[Union[Sequence[str], str]] = None,
-        dataset: Optional[Union[Sequence[str], str]] = None,
+        model_id: Union[Sequence[str], str],
+        dataset: Union[Sequence[str], str],
     ) -> Dict[str, Dict[str, dict]]:
         """Evaluates models on datasets.
         

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -40,6 +40,7 @@ class Evaluator:
             specified then it will be used as the token. Defaults to False.
         verbose (bool, optional):
             Whether to output additional output. Defaults to False.
+            
     Attributes:
         progress_bar (bool): Whether progress bars should be shown.
         save_results (bool): Whether to save the benchmark results.

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -89,7 +89,7 @@ class Evaluator:
         # Initialise a task factory
         self.task_factory = TaskFactory(evaluation_config=self.evaluation_config)
 
-    def benchmark(
+    def evaluate(
         self,
         model_id: Optional[Union[Sequence[str], str]] = None,
         dataset: Optional[Union[Sequence[str], str]] = None,

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -197,3 +197,17 @@ class Evaluator:
             dataset_tasks = [dataset_task_mapping[task] for task in dataset_task]
 
         return dataset_tasks
+
+    def _prepare_model_tasks(
+        self, model_task: Optional[Union[str, Sequence[str]]]
+    ) -> Optional[Sequence[str]]:
+        """Prepare model task(s) for benchmarking.
+        Args:
+            model_task (str or list of str):
+                The tasks to include for models. If "all" then models will not be
+                filtered based on the task they were trained on.
+        Returns:
+            None or sequence of str:
+                The prepared model tasks.
+        """
+        return [model_task] if isinstance(model_task, str) else model_task

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 class Evaluator:
     """Evaluating provided Danish language models.
-    
+
     Args:
         progress_bar (bool, optional):
             Whether progress bars should be shown. Defaults to True.
@@ -40,7 +40,7 @@ class Evaluator:
             specified then it will be used as the token. Defaults to False.
         verbose (bool, optional):
             Whether to output additional output. Defaults to False.
-            
+
     Attributes:
         progress_bar (bool): Whether progress bars should be shown.
         save_results (bool): Whether to save the benchmark results.
@@ -97,13 +97,13 @@ class Evaluator:
         dataset: Union[Sequence[str], str],
     ) -> Dict[str, Dict[str, dict]]:
         """Evaluates models on datasets.
-        
+
         Args:
             model_id (str or list of str):
                 The model ID(s) of the models to be evaluated.
             dataset (str or list of str):
                 The dataset(s) to evaluate the model(s) on.
-                
+
         Returns:
             dict:
                 A nested dictionary of the benchmark results. The keys are the names of

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 class Evaluator:
     """Evaluating provided Danish language models.
+    
     Args:
         progress_bar (bool, optional):
             Whether progress bars should be shown. Defaults to True.

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -31,7 +31,7 @@ class Evaluator:
         raise_error_on_invalid_model (bool, optional):
             Whether to raise an error if a model is invalid. Defaults to False.
         cache_dir (str, optional):
-            Directory to store cached models. Defaults to '.scandeval_cache'.
+            Directory to store cached models. Defaults to '.aiai_eval_cache'.
         use_auth_token (bool or str, optional):
             The authentication token for the Hugging Face Hub. If a boolean value is
             specified then the token will be fetched from the Hugging Face CLI, where

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -86,8 +86,8 @@ class Evaluator:
         logging_level = logging.DEBUG if verbose else logging.INFO
         logger.setLevel(logging_level)
 
-        # Initialise a dataset factory
-        self.dataset_factory = TaskFactory(evaluation_config=self.evaluation_config)
+        # Initialise a task factory
+        self.task_factory = TaskFactory(evaluation_config=self.evaluation_config)
 
     def benchmark(
         self,

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -1,1 +1,199 @@
 """Main Evaluator class, used to evaluate models."""
+
+
+import json
+import logging
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Union
+
+from .config import DatasetConfig, DatasetTask, EvaluationConfig
+from .task_configs import get_all_dataset_tasks
+from .task_factory import TaskFactory
+
+logger = logging.getLogger(__name__)
+
+
+class Evaluator:
+    """Evaluating provided Danish language models.
+    Args:
+        progress_bar (bool, optional):
+            Whether progress bars should be shown. Defaults to True.
+        save_results (bool, optional):
+            Whether to save the benchmark results to
+            'scandeval_benchmark_results.json'. Defaults to False.
+        model_task (str or sequence of str, optional):
+            The tasks to include for models. If "all" then models will not be filtered
+            based on the task they were trained on. Defaults to "all".
+        dataset_task (str or sequence of str, optional):
+            The tasks to include for dataset. If "all" then datasets will not be
+            filtered based on their task. Defaults to "all".
+        raise_error_on_invalid_model (bool, optional):
+            Whether to raise an error if a model is invalid. Defaults to False.
+        cache_dir (str, optional):
+            Directory to store cached models. Defaults to '.scandeval_cache'.
+        use_auth_token (bool or str, optional):
+            The authentication token for the Hugging Face Hub. If a boolean value is
+            specified then the token will be fetched from the Hugging Face CLI, where
+            the user has logged in through `huggingface-cli login`. If a string is
+            specified then it will be used as the token. Defaults to False.
+        verbose (bool, optional):
+            Whether to output additional output. Defaults to False.
+    Attributes:
+        progress_bar (bool): Whether progress bars should be shown.
+        save_results (bool): Whether to save the benchmark results.
+        model_task (str or list of str): The model tasks to include.
+        dataset_task (str or list of str): The dataset tasks to include.
+        verbose (bool): Whether to output additional output.
+        use_auth_token (str or bool): The authentication token for the Hugging Face Hub.
+        evaluation_results (dict): The benchmark results.
+    """
+
+    def __init__(
+        self,
+        progress_bar: bool = True,
+        save_results: bool = False,
+        model_task: Optional[Union[str, Sequence[str]]] = None,
+        dataset_task: Optional[Union[str, Sequence[str]]] = None,
+        raise_error_on_invalid_model: bool = False,
+        cache_dir: str = ".aiai_eval_cache",
+        use_auth_token: Union[bool, str] = False,
+        verbose: bool = False,
+    ):
+        # Build dataset tasks
+        dataset_tasks = self._prepare_dataset_tasks(dataset_task)
+
+        # Build evaluation configuration
+        self.evaluation_config = EvaluationConfig(
+            model_tasks=model_task,
+            dataset_tasks=dataset_tasks,
+            raise_error_on_invalid_model=raise_error_on_invalid_model,
+            cache_dir=cache_dir,
+            use_auth_token=use_auth_token,
+            progress_bar=progress_bar,
+            save_results=save_results,
+            verbose=verbose,
+        )
+
+        # Initialise variable storing model lists, so we only have to fetch it once
+        self._model_lists: Union[Dict[str, Sequence[str]], None] = None
+
+        # Initialise variable storing all evaluation results, which will be
+        # updated as more models are benchmarked
+        self.evaluation_results: Dict[str, dict] = defaultdict(dict)
+
+        # Set logging level based on verbosity
+        logging_level = logging.DEBUG if verbose else logging.INFO
+        logger.setLevel(logging_level)
+
+        # Initialise a dataset factory
+        self.dataset_factory = TaskFactory(evaluation_config=self.evaluation_config)
+
+    def benchmark(
+        self,
+        model_id: Optional[Union[Sequence[str], str]] = None,
+        dataset: Optional[Union[Sequence[str], str]] = None,
+    ) -> Dict[str, Dict[str, dict]]:
+        """Benchmarks models on datasets.
+        Args:
+            model_id (str, list of str or None, optional):
+                The model ID(s) of the models to benchmark. If None then all relevant
+                model IDs will be benchmarked. Defaults to None.
+            dataset (str, list of str or None, optional):
+                The datasets to benchmark on. If None then all datasets will be
+                benchmarked. Defaults to None.
+        Returns:
+            dict:
+                A nested dictionary of the benchmark results. The keys are the names of
+                the datasets, with values being new dictionaries having the model IDs
+                as keys.
+        """
+        pass
+
+    def _prepare_model_ids(
+        self,
+        model_id: Optional[Union[Sequence[str], str]],
+    ) -> Sequence[str]:
+        """Prepare the model ID(s) to be benchmarked.
+        Args:
+            model_id (str, list of str or None):
+                The model ID(s) of the models to benchmark. If None then all model IDs
+                will be retrieved.
+        Returns:
+            sequence of str:
+                The prepared list of model IDs.
+        """
+        pass
+
+    def _prepare_dataset_configs(
+        self,
+        dataset: Optional[Union[Sequence[str], str]],
+    ) -> Sequence[DatasetConfig]:
+        """Prepare the dataset configuration(s) to be benchmarked.
+        Args:
+            dataset (str, list of str or None, optional):
+                The datasets to benchmark on. If None then all datasets will be
+                benchmarked. Defaults to None.
+        Returns:
+            sequence of str:
+                The prepared list of model IDs.
+        """
+        pass
+
+    def _benchmark_single(
+        self,
+        dataset_config: DatasetConfig,
+        model_id: str,
+    ):
+        """Benchmark a single model on a single dataset.
+        Args:
+            dataset_config (DatasetConfig):
+                The dataset configuration to use.
+            model_id (str):
+                The model ID to use.
+        """
+        pass
+
+    def __call__(self, *args, **kwargs):
+        pass
+
+    def _get_fresh_model_ids(
+        self,
+        tasks: Optional[Sequence[str]],
+    ) -> list:
+        """Get list of model IDs from the Hugging Face Hub.
+        Args:
+            tasks (None or sequence of str):
+                The tasks of the models to fetch. If None then the models will not be
+                filtered on tasks.
+        Returns:
+            list:
+                List of model IDs.
+        """
+        pass
+
+    def _prepare_dataset_tasks(
+        self, dataset_task: Optional[Union[str, Sequence[str]]]
+    ) -> Sequence[DatasetTask]:
+        """Prepare dataset task(s) for benchmarking.
+        Args:
+            dataset_task (str or sequence of str, optional):
+                The tasks to include for dataset. If "all" then datasets will not be
+                filtered based on their task. Defaults to "all".
+        Returns:
+            sequence of DatasetTask:
+                The prepared dataset tasks.
+        """
+        # Create a dictionary that maps benchmark tasks to their associated benchmark
+        # task objects
+        dataset_task_mapping = get_all_dataset_tasks()
+
+        # Create the list of dataset tasks
+        if dataset_task is None:
+            dataset_tasks = list(dataset_task_mapping.values())
+        elif isinstance(dataset_task, str):
+            dataset_tasks = [dataset_task_mapping[dataset_task]]
+        else:
+            dataset_tasks = [dataset_task_mapping[task] for task in dataset_task]
+
+        return dataset_tasks

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -117,11 +117,11 @@ class Evaluator:
         model_id: Optional[Union[Sequence[str], str]],
     ) -> Sequence[str]:
         """Prepare the model ID(s) to be benchmarked.
-        
+
         Args:
             model_id (str or list of str):
                 The model ID(s) of the models to be evaluated.
-                
+
         Returns:
             sequence of str:
                 The prepared list of model IDs.
@@ -133,11 +133,11 @@ class Evaluator:
         dataset: Optional[Union[Sequence[str], str]],
     ) -> Sequence[DatasetConfig]:
         """Prepare the task configuration(s) to be benchmarked.
-        
+
         Args:
             task (str or list of str):
                 The tasks to evaluate.
-                
+
         Returns:
             sequence of TaskConfig:
                 The prepared list of task configurations.
@@ -150,7 +150,7 @@ class Evaluator:
         model_id: str,
     ):
         """Benchmark a single model on a single dataset.
-        
+
         Args:
             dataset_config (DatasetConfig):
                 The dataset configuration to use.
@@ -167,12 +167,12 @@ class Evaluator:
         tasks: Optional[Sequence[str]],
     ) -> list:
         """Get list of model IDs from the Hugging Face Hub.
-        
+
         Args:
             tasks (None or sequence of str):
                 The tasks of the models to fetch. If None then the models will not be
                 filtered on tasks.
-                
+
         Returns:
             list:
                 List of model IDs.
@@ -183,12 +183,12 @@ class Evaluator:
         self, dataset_task: Optional[Union[str, Sequence[str]]]
     ) -> Sequence[DatasetTask]:
         """Prepare dataset task(s) for benchmarking.
-        
+
         Args:
             dataset_task (str or sequence of str, optional):
                 The tasks to include for dataset. If "all" then datasets will not be
                 filtered based on their task. Defaults to "all".
-                
+
         Returns:
             sequence of DatasetTask:
                 The prepared dataset tasks.
@@ -211,12 +211,12 @@ class Evaluator:
         self, model_task: Optional[Union[str, Sequence[str]]]
     ) -> Optional[Sequence[str]]:
         """Prepare model task(s) for benchmarking.
-        
+
         Args:
             model_task (str or list of str):
                 The tasks to include for models. If "all" then models will not be
                 filtered based on the task they were trained on.
-                
+
         Returns:
             None or sequence of str:
                 The prepared model tasks.

--- a/src/aiai_eval/task_configs.py
+++ b/src/aiai_eval/task_configs.py
@@ -7,6 +7,7 @@ from .config import DatasetTask, Label, MetricConfig
 
 def get_all_dataset_tasks() -> Dict[str, DatasetTask]:
     """Get a list of all the dataset tasks.
+    
     Returns:
         dict:
             A mapping between names of dataset tasks and their configurations.

--- a/src/aiai_eval/task_configs.py
+++ b/src/aiai_eval/task_configs.py
@@ -15,37 +15,6 @@ def get_all_dataset_tasks() -> Dict[str, DatasetTask]:
     return {cfg.name: cfg for cfg in globals().values() if isinstance(cfg, DatasetTask)}
 
 
-LA = DatasetTask(
-    name="la",
-    supertask="text-classification",
-    metrics=[
-        MetricConfig(
-            name="mcc",
-            pretty_name="Matthew's Correlation Coefficient",
-            huggingface_id="matthews_correlation",
-            results_key="matthews_correlation",
-        ),
-        MetricConfig(
-            name="macro_f1",
-            pretty_name="Macro-average F1-score",
-            huggingface_id="f1",
-            results_key="f1",
-            compute_kwargs=dict(average="macro"),
-        ),
-    ],
-    labels=[
-        Label(
-            name="INCORRECT",
-            synonyms=["LABEL_0"],
-        ),
-        Label(
-            name="CORRECT",
-            synonyms=["LABEL_1"],
-        ),
-    ],
-)
-
-
 NER = DatasetTask(
     name="ner",
     supertask="token-classification",

--- a/src/aiai_eval/task_configs.py
+++ b/src/aiai_eval/task_configs.py
@@ -1,1 +1,245 @@
 """All task configurations used in the project."""
+
+from typing import Dict
+
+from .config import DatasetTask, Label, MetricConfig
+
+
+def get_all_dataset_tasks() -> Dict[str, DatasetTask]:
+    """Get a list of all the dataset tasks.
+    Returns:
+        dict:
+            A mapping between names of dataset tasks and their configurations.
+    """
+    return {cfg.name: cfg for cfg in globals().values() if isinstance(cfg, DatasetTask)}
+
+
+LA = DatasetTask(
+    name="la",
+    supertask="text-classification",
+    metrics=[
+        MetricConfig(
+            name="mcc",
+            pretty_name="Matthew's Correlation Coefficient",
+            huggingface_id="matthews_correlation",
+            results_key="matthews_correlation",
+        ),
+        MetricConfig(
+            name="macro_f1",
+            pretty_name="Macro-average F1-score",
+            huggingface_id="f1",
+            results_key="f1",
+            compute_kwargs=dict(average="macro"),
+        ),
+    ],
+    labels=[
+        Label(
+            name="INCORRECT",
+            synonyms=["LABEL_0"],
+        ),
+        Label(
+            name="CORRECT",
+            synonyms=["LABEL_1"],
+        ),
+    ],
+)
+
+
+NER = DatasetTask(
+    name="ner",
+    supertask="token-classification",
+    metrics=[
+        MetricConfig(
+            name="micro_f1",
+            pretty_name="Micro-average F1-score",
+            huggingface_id="seqeval",
+            results_key="overall_f1",
+        ),
+        MetricConfig(
+            name="micro_f1_no_misc",
+            pretty_name="Micro-average F1-score without MISC tags",
+            huggingface_id="seqeval",
+            results_key="overall_f1",
+        ),
+    ],
+    labels=[
+        Label(
+            name="O",
+            synonyms=[],
+        ),
+        Label(
+            name="B-LOC",
+            synonyms=[
+                "B-LOCATION",
+                "B-PLACE",
+                "B-GPELOC",
+                "B-GPE_LOC",
+                "B-GPE/LOC",
+                "B-LOCGPE",
+                "B-LOC_GPE",
+                "B-LOC/GPE",
+                "B-LOCORG",
+                "B-LOC_ORG",
+                "B-LOC/ORG",
+                "B-ORGLOC",
+                "B-ORG_LOC",
+                "B-ORG/LOC",
+                "B-LOCPRS",
+                "B-LOC_PRS",
+                "B-LOC/PRS",
+                "B-PRSLOC",
+                "B-PRS_LOC",
+                "B-PRS/LOC",
+            ],
+        ),
+        Label(
+            name="I-LOC",
+            synonyms=[
+                "I-LOCATION",
+                "I-PLACE",
+                "I-GPELOC",
+                "I-GPE_LOC",
+                "I-GPE/LOC",
+                "I-LOCGPE",
+                "I-LOC_GPE",
+                "I-LOC/GPE",
+                "I-LOCORG",
+                "I-LOC_ORG",
+                "I-LOC/ORG",
+                "I-ORGLOC",
+                "I-ORG_LOC",
+                "I-ORG/LOC",
+                "I-LOCPRS",
+                "I-LOC_PRS",
+                "I-LOC/PRS",
+                "I-PRSLOC",
+                "I-PRS_LOC",
+                "I-PRS/LOC",
+            ],
+        ),
+        Label(
+            name="B-ORG",
+            synonyms=[
+                "B-ORGANIZATION",
+                "B-ORGANISATION",
+                "B-INST",
+                "B-GPEORG",
+                "B-GPE_ORG",
+                "B-GPE/ORG",
+                "B-ORGGPE",
+                "B-ORG_GPE",
+                "B-ORG/GPE",
+                "B-ORGPRS",
+                "B-ORG_PRS",
+                "B-ORG/PRS",
+                "B-PRSORG",
+                "B-PRS_ORG",
+                "B-PRS/ORG",
+                "B-OBJORG",
+                "B-OBJ_ORG",
+                "B-OBJ/ORG",
+                "B-ORGOBJ",
+                "B-ORG_OBJ",
+                "B-ORG/OBJ",
+            ],
+        ),
+        Label(
+            name="I-ORG",
+            synonyms=[
+                "I-ORGANIZATION",
+                "I-ORGANISATION",
+                "I-INST",
+                "I-GPEORG",
+                "I-GPE_ORG",
+                "I-GPE/ORG",
+                "I-ORGGPE",
+                "I-ORG_GPE",
+                "I-ORG/GPE",
+                "I-ORGPRS",
+                "I-ORG_PRS",
+                "I-ORG/PRS",
+                "I-PRSORG",
+                "I-PRS_ORG",
+                "I-PRS/ORG",
+                "I-OBJORG",
+                "I-OBJ_ORG",
+                "I-OBJ/ORG",
+                "I-ORGOBJ",
+                "I-ORG_OBJ",
+                "I-ORG/OBJ",
+            ],
+        ),
+        Label(
+            name="B-PER",
+            synonyms=["B-PERSON"],
+        ),
+        Label(
+            name="I-PER",
+            synonyms=["I-PERSON"],
+        ),
+        Label(
+            name="B-MISC",
+            synonyms=["B-MISCELLANEOUS"],
+        ),
+        Label(
+            name="I-MISC",
+            synonyms=["I-MISCELLANEOUS"],
+        ),
+    ],
+)
+
+
+QA = DatasetTask(
+    name="qa",
+    supertask="question-answering",
+    metrics=[
+        MetricConfig(
+            name="em",
+            pretty_name="Exact Match",
+            huggingface_id="exact_match",
+            results_key="exact_match",
+        ),
+        MetricConfig(
+            name="f1",
+            pretty_name="F1-score of the positive class",
+            huggingface_id="f1",
+            results_key="f1",
+        ),
+    ],
+    labels=[],
+)
+
+
+SENT = DatasetTask(
+    name="sent",
+    supertask="text-classification",
+    metrics=[
+        MetricConfig(
+            name="mcc",
+            pretty_name="Matthew's Correlation Coefficient",
+            huggingface_id="matthews_correlation",
+            results_key="matthews_correlation",
+        ),
+        MetricConfig(
+            name="macro_f1",
+            pretty_name="Macro-average F1-score",
+            huggingface_id="f1",
+            results_key="f1",
+            compute_kwargs=dict(average="macro"),
+        ),
+    ],
+    labels=[
+        Label(
+            name="NEGATIVE",
+            synonyms=["NEG", "NEGATIV", "LABEL_0"],
+        ),
+        Label(
+            name="NEUTRAL",
+            synonyms=["NEU", "LABEL_1"],
+        ),
+        Label(
+            name="POSITIVE",
+            synonyms=["POS", "POSITIV", "LABEL_2"],
+        ),
+    ],
+)

--- a/src/aiai_eval/task_configs.py
+++ b/src/aiai_eval/task_configs.py
@@ -7,7 +7,7 @@ from .config import DatasetTask, Label, MetricConfig
 
 def get_all_dataset_tasks() -> Dict[str, DatasetTask]:
     """Get a list of all the dataset tasks.
-    
+
     Returns:
         dict:
             A mapping between names of dataset tasks and their configurations.

--- a/src/aiai_eval/task_factory.py
+++ b/src/aiai_eval/task_factory.py
@@ -7,9 +7,11 @@ from .config import EvaluationConfig
 
 class TaskFactory:
     """Factory which produces tasks from a configuration.
+    
     Args:
         evaluation_config (EvaluationConfig):
             The benchmark configuration to be used in all tasks constructed.
+            
     Attributes:
         evaluation_config (EvaluationConfig):
             The benchmark configuration to be used in all tasks constructed.

--- a/src/aiai_eval/task_factory.py
+++ b/src/aiai_eval/task_factory.py
@@ -1,1 +1,21 @@
 """Factory that produces tasks from a task configuration."""
+
+from typing import Type, Union
+
+from .config import EvaluationConfig
+
+
+class TaskFactory:
+    """Factory which produces tasks from a configuration.
+    Args:
+        evaluation_config (EvaluationConfig):
+            The benchmark configuration to be used in all tasks constructed.
+    Attributes:
+        evaluation_config (EvaluationConfig):
+            The benchmark configuration to be used in all tasks constructed.
+    """
+
+    def __init__(self, evaluation_config: EvaluationConfig):
+        self.evaluation_config = evaluation_config
+
+    # TODO build_dataset(DatasetConfig)

--- a/src/aiai_eval/task_factory.py
+++ b/src/aiai_eval/task_factory.py
@@ -7,11 +7,11 @@ from .config import EvaluationConfig
 
 class TaskFactory:
     """Factory which produces tasks from a configuration.
-    
+
     Args:
         evaluation_config (EvaluationConfig):
             The benchmark configuration to be used in all tasks constructed.
-            
+
     Attributes:
         evaluation_config (EvaluationConfig):
             The benchmark configuration to be used in all tasks constructed.


### PR DESCRIPTION
This PR introduces:

- dataclasses for different types of configs.
- task configs.
- the task factory, without `build_dataset`.
- evaluator/benchmarker, without associated functions.

I removed all references to language, as we are focusing on danish. 

I did not port the `benchmark_config_factory.py` as most of what it does pertains to language selection, and the rest (`_prepare_model_tasks` and `_prepare_dataset_tasks`) was added to `evaluator.py`·

I did not include `build_dataset` in the `task_factory.py`, will come in a seperate PR later, when i have a better overview.